### PR TITLE
Missing dependency on `html5`

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "connect-gzip": "",
     "redis": "",
     "socket.io":"",
+    "html5":"",
     "jsdom": ""
   },
   "keywords" : [


### PR DESCRIPTION
After a clean `git clone` and `npm install`, this was the only thing apparently missing.
